### PR TITLE
Fix issue with ranking modal not opening for loss scenarios

### DIFF
--- a/src/components/modal/RankingModal.tsx
+++ b/src/components/modal/RankingModal.tsx
@@ -62,7 +62,7 @@ export default function RankingModal({appTitle}: Props) {
     useDebounce(() => {
         if (!currentUserSolution) return;
 
-        if (currentUserSolution.state === "Win") {
+        if (currentUserSolution.state !== "Unsolved") {
             onOpen();
         }
     }, 100, [currentUserSolution]);


### PR DESCRIPTION
---

**Description:**

Updated the code to fix the issue where the ranking modal was not opening for loss scenarios. Now the modal functionality works correctly, allowing users to view their ranking even after a loss.